### PR TITLE
Expect access code in control calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,12 @@ Here is a short script that can be used to schedule arming/disarming the alarm u
 from simon_says.client import Client
 import argparse
 
-
 def parse_args() -> argparse.Namespace:
     """ Parse command line arguments """
     parser = argparse.ArgumentParser(description="Alarm Schedule")
     parser.add_argument(
-        "-a", "--action", type=str, help="Action to execute", required=True, choices=["arm", "disarm"]
+        "-a", "--action", type=str, help="Action to execute", required=True, choices=["arm", "disarm"],
+        "-c", "--code", type=str, help="Access Code", required=True
     )
     return parser.parse_args()
 
@@ -156,9 +156,9 @@ if __name__ == "__main__":
     client = Client(url="http://localhost:8000")
 
     if args.action == "arm":
-        client.arm_home()
+        client.arm_home(args.code)
     elif args.action == "disarm":
-        client.disarm()
+        client.disarm(args.code)
 ```
 
 And the corresponding cron jobs:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,12 @@
+[mypy]
+python_version = 3.7
+strict_optional = true
+follow_imports = silent
+warn_return_any = false
+
+## silence mypy about modules which don't have type information.
+[mypy-pycall]
+ignore_missing_imports = true
+
+[mypy-falcon]
+ignore_missing_imports = true

--- a/simon_says/client.py
+++ b/simon_says/client.py
@@ -20,26 +20,23 @@ class Client(object):
         else:
             raise RuntimeError(f"Error code: {r.status_code}, content: {r.text}")
 
-    def arm_home(self, timeout: int = DEFAULT_TIMEOUT) -> str:
-        r = self._session.post(f"{self._url}/control", json={"action": "arm_home"}, timeout=timeout)
+    def _action(self, action: str, access_code: str, timeout: int = DEFAULT_TIMEOUT) -> str:
+        r = self._session.post(
+            f"{self._url}/control", json={"action": action, "access_code": access_code}, timeout=timeout
+        )
         if r.status_code == 202:
             return r.json()
         else:
             raise RuntimeError(f"Error code: {r.status_code}, content: {r.text}")
 
-    def arm_away(self, timeout: int = DEFAULT_TIMEOUT) -> str:
-        r = self._session.post(f"{self._url}/control", json={"action": "arm_away"}, timeout=timeout)
-        if r.status_code == 202:
-            return r.json()
-        else:
-            raise RuntimeError(f"Error code: {r.status_code}, content: {r.text}")
+    def arm_home(self, access_code: str, timeout: int = DEFAULT_TIMEOUT) -> str:
+        return self._action(timeout=timeout, action="arm_home", access_code=access_code)
 
-    def disarm(self, timeout: int = DEFAULT_TIMEOUT) -> str:
-        r = self._session.post(f"{self._url}/control", json={"action": "disarm"}, timeout=timeout)
-        if r.status_code == 202:
-            return r.json()
-        else:
-            raise RuntimeError(f"Error code: {r.status_code}, content: {r.text}")
+    def arm_away(self, access_code: str, timeout: int = DEFAULT_TIMEOUT) -> str:
+        return self._action(timeout=timeout, action="arm_away", access_code=access_code)
+
+    def disarm(self, access_code: str, timeout: int = DEFAULT_TIMEOUT) -> str:
+        return self._action(timeout=timeout, action="disarm", access_code=access_code)
 
     def add_event(self, data: Dict, timeout: int = DEFAULT_TIMEOUT) -> str:
         """ Add a single event """

--- a/simon_says/config.py
+++ b/simon_says/config.py
@@ -17,8 +17,6 @@ DEFAULTS = {
         "dst_dir": "/var/spool/asterisk/alarm_events_processed",
     },
     "control": {
-        # Default alarm access code
-        "access_code": "1234",
         # SIP extension that will receive the commands via Asterisk
         "extension": "100",
         # How long to wait for the alarm to answer
@@ -45,7 +43,7 @@ class ConfigLoader:
         self.load_from_file(cfg_path)
 
     def load_defaults(self) -> None:
-        self.config.read_dict(DEFAULTS)
+        self.config.read_dict(DEFAULTS)  # type: ignore
 
     def load_from_file(self, cfg_path) -> None:
         """ Load config file """

--- a/simon_says/events.py
+++ b/simon_says/events.py
@@ -192,6 +192,7 @@ class EventParser:
                     return event_data
 
         logger.warning("No events found in file %s", path)
+        return None
 
     def move_file(self, src: Path) -> None:
         """ Move event file to processed folder """

--- a/simon_says/sensors.py
+++ b/simon_says/sensors.py
@@ -42,7 +42,7 @@ class Sensors:
     """
 
     def __init__(self, config: ConfigParser = None) -> None:
-        self._sensors_by_number = {}
+        self._sensors_by_number: Dict[int, Sensor] = {}
         self.cfg = config or ConfigLoader().config
         self._load_from_config()
 

--- a/test/functional/test_client.py
+++ b/test/functional/test_client.py
@@ -5,7 +5,13 @@ from simon_says.app import create_app
 from simon_says.client import Client
 from simon_says.helpers import redis_present
 
+#
+# To run a redis instance locally for testing:
+#   docker run --name my-redis -p 6379:6379 --restart always --detach redis
+#
 pytestmark = pytest.mark.skipif(not redis_present(), reason="redis not present")
+
+CODE = "1234"
 
 
 @pytest.fixture
@@ -40,17 +46,17 @@ def test_client_add_and_get_events(test_client, test_parsed_events):
 
 
 def test_client_arm_home(test_client):
-    res = test_client.arm_home()
+    res = test_client.arm_home(access_code=CODE)
     assert res["result"] == "OK"
 
 
 def test_client_arm_away(test_client):
-    res = test_client.arm_away()
+    res = test_client.arm_away(access_code=CODE)
     assert res["result"] == "OK"
 
 
 def test_client_disarm(test_client):
-    res = test_client.disarm()
+    res = test_client.disarm(access_code=CODE)
     assert res["result"] == "OK"
 
 

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -48,7 +48,7 @@ def test_post_and_get_events(client, test_parsed_events, test_db):
 
 
 def test_controller_disarm(client, tmp_path):
-    data = {"action": "disarm"}
+    data = {"action": "disarm", "access_code": "1234"}
     resp = client.simulate_post("/control", json=data)
     assert resp.status == falcon.HTTP_ACCEPTED
 

--- a/test/test_control.py
+++ b/test/test_control.py
@@ -1,10 +1,13 @@
+ACCESS_CODE = "1234"
+
+
 def test_build_dtmf(test_controller):
-    dtmf = test_controller._build_dtmf_sequence("arm_doors_and_windows_no_delay")
+    dtmf = test_controller._build_dtmf_sequence("arm_doors_and_windows_no_delay", access_code=ACCESS_CODE)
     assert dtmf == "ww1234w2w2w9"
 
 
 def test_send_disarm_command(test_controller, tmp_path):
-    test_controller.send_command("disarm")
+    test_controller.send_command("disarm", access_code=ACCESS_CODE)
     call_file = next(tmp_path.iterdir())
     lines = call_file.read_text().splitlines()
     assert lines[0] == "Channel: SIP/100"
@@ -12,14 +15,14 @@ def test_send_disarm_command(test_controller, tmp_path):
     assert lines[2] == "RetryTime: 10"
     assert lines[3] == "Maxretries: 2"
     assert lines[4] == "Application: SendDTMF"
-    assert lines[5] == "Data: ww1234w1w9"
+    assert lines[5] == f"Data: ww{ACCESS_CODE}w1w9"
     assert lines[6] == "Archive: yes"
     call_file.unlink()
 
 
 def test_arm_doors_and_windows_no_delay(test_controller, tmp_path):
-    test_controller.send_command("arm_doors_and_windows_no_delay")
+    test_controller.send_command("arm_doors_and_windows_no_delay", access_code=ACCESS_CODE)
     call_file = next(tmp_path.iterdir())
     lines = call_file.read_text().splitlines()
-    assert lines[5] == "Data: ww1234w2w2w9"
+    assert lines[5] == f"Data: ww{ACCESS_CODE}w2w2w9"
     call_file.unlink()

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,14 @@ commands =
     pytest
 
 [testenv:lint]
-commands = flake8
-deps = flake8
+commands =
+    isort --check --diff .
+    black --check --diff .
+    flake8
+deps =
+    flake8
+    black
+    isort
 
 [testenv:format]
 commands =
@@ -31,3 +37,15 @@ exclude =
     .mypy_cache
     .venv
     .pytest_cache
+
+[testenv:mypy]
+basepython=python3
+skip_install=True
+whitelist_externals=
+    /bin/sh
+    /usr/bin/sh
+deps =
+  mypy
+  .[dev]
+commands =
+  mypy --install-types --non-interactive simon_says/


### PR DESCRIPTION
Originally I had envisioned using HTTP authentication for accessing the API. On second thought, it's better to just expect the code when calling the control resource on the API. 

Commit includes adding mypy to tox, fixing mypy and other minor issues.